### PR TITLE
[Web] Video bug fix

### DIFF
--- a/lib/src/web/rtc_video_renderer_impl.dart
+++ b/lib/src/web/rtc_video_renderer_impl.dart
@@ -55,8 +55,11 @@ class RTCVideoRendererWeb extends VideoRenderer {
 
   bool _muted = false;
 
-  set objectFit(String fit) =>
-      findHtmlView()?.style.objectFit = _objectFit = fit;
+  set objectFit(String fit) {
+    if (_objectFit == fit) return;
+    _objectFit = fit;
+    findHtmlView()?.style.objectFit = fit;
+  }
 
   @override
   int get videoWidth => value.width.toInt();


### PR DESCRIPTION
Fixes bug where `html.VideoElement` doesn't respect initial value of `objectFit` for **Web**.
For example, now the following code will work. 
```dart
RTCVideoView(
  objectFit: RTCVideoViewObjectFit.RTCVideoViewObjectFitCover,
  // ...
)
```
Interesting how these bugs are often simple fixes 😅.